### PR TITLE
Refine cond dist

### DIFF
--- a/gower_metric/core/metric.py
+++ b/gower_metric/core/metric.py
@@ -28,6 +28,7 @@ from gower_metric.utils.validators import (
     validate_categorical_ordinal_values_order,
     validate_conditional_distances,
     validate_feature_types,
+    validate_feature_types_for_conditional_distances,
     validate_k_neighbours,
     validate_missing_strategy,
     validate_scale_method,
@@ -165,6 +166,9 @@ class Gower:
         Returns:
             Gower: The fitted instance.
 
+        Raises:
+            ValueError: For incorrect input data and configuration parameters.
+
         Example:
             >>> import pandas as pd
             >>> from gower_metric import Gower
@@ -240,6 +244,16 @@ class Gower:
             else np.array(X, dtype=object)
         )
 
+        self.n_feats = arr.shape[1]
+        if self.conditional_distances:
+            self.p_cat = (
+                len(self.binary_symmetric_indices)
+                + len(self.binary_asymmetric_indices)
+                + len(self.categorical_nominal_indices)
+                + len(self.categorical_ordinal_indices)
+            )
+            validate_feature_types_for_conditional_distances(self.n_feats, self.p_cat)
+
         if self.ratio_scale_indices:
             self.ratio_ranges = get_numeric_ranges(
                 arr, self.ratio_scale_indices, self.scale_method
@@ -305,20 +319,12 @@ class Gower:
                 "max": mx,
             }
 
-        n_feats = arr.shape[1]
         self.weights = get_weights(
-            n_features=n_feats,
+            n_features=self.n_feats,
             config=self.feature_weights,
         )
 
         self._is_fitted = True
-
-        self.p_cat = (
-            len(self.binary_symmetric_indices)
-            + len(self.binary_asymmetric_indices)
-            + len(self.categorical_nominal_indices)
-            + len(self.categorical_ordinal_indices)
-        )
         return self
 
     def transform(self, X: pd.DataFrame | np.ndarray) -> pd.DataFrame | np.ndarray:

--- a/gower_metric/core/metric.py
+++ b/gower_metric/core/metric.py
@@ -317,6 +317,7 @@ class Gower:
             len(self.binary_symmetric_indices)
             + len(self.binary_asymmetric_indices)
             + len(self.categorical_nominal_indices)
+            + len(self.categorical_ordinal_indices)
         )
         return self
 
@@ -510,6 +511,16 @@ class Gower:
             weights=cat_nom_w,
         )
 
+        cat_ord_sum, cat_ord_count = categorical_ordinal_component(
+            Xn,
+            Yn,
+            self.categorical_ordinal_indices,
+            metadata=self.cat_ord_metadata,
+            missing_strategy=self.missing_strategy,
+            calculation_type=self.categorical_ordinal_calculation_type,
+            weights=cat_ord_w,
+        )
+
         if self.conditional_distances:
             cat_sum = 0.0
             cat_cnt = 0.0
@@ -525,6 +536,10 @@ class Gower:
             if self.categorical_nominal_indices:
                 cat_sum += cat_nom_sum[0, 0]
                 cat_cnt += cat_nom_count[0, 0]
+
+            if self.categorical_ordinal_indices:
+                cat_sum += cat_ord_sum[0, 0]
+                cat_cnt += cat_ord_count[0, 0]
 
             if cat_cnt == 0:
                 return float("nan")
@@ -545,15 +560,7 @@ class Gower:
             weights=num_w,
             scale_window=self.scale_window,
         )
-        cat_ord_sum, cat_ord_count = categorical_ordinal_component(
-            Xn,
-            Yn,
-            self.categorical_ordinal_indices,
-            metadata=self.cat_ord_metadata,
-            missing_strategy=self.missing_strategy,
-            calculation_type=self.categorical_ordinal_calculation_type,
-            weights=cat_ord_w,
-        )
+
         ratio_sum, ratio_count = ratio_scale_component(
             Xn,
             Yn,
@@ -566,8 +573,8 @@ class Gower:
         )
 
         if self.conditional_distances:
-            total_sum = num_sum + cat_ord_sum + ratio_sum
-            total_count = num_count + cat_ord_count + ratio_count
+            total_sum = num_sum + ratio_sum
+            total_count = num_count + ratio_count
         else:
             total_sum = (
                 num_sum

--- a/gower_metric/core/metric.py
+++ b/gower_metric/core/metric.py
@@ -27,6 +27,7 @@ from gower_metric.utils.validators import (
     validate_categorical_ordinal_calculation_type,
     validate_categorical_ordinal_values_order,
     validate_conditional_distances,
+    validate_conditional_distances_threshold_coeff,
     validate_feature_types,
     validate_feature_types_for_conditional_distances,
     validate_k_neighbours,
@@ -55,6 +56,7 @@ class Gower:
         scale_window_type: str | None = None,
         k_neighbours: int | None = None,
         conditional_distances: bool = False,
+        conditional_distances_threshold_coeff: int = 1,
     ) -> None:
         """
         Initialize Gower with explicit feature type and weight mappings.
@@ -83,6 +85,9 @@ class Gower:
                 set to the square root of the number of points.
             conditional_distances (bool): Default to False. If set to True, two-step approach will be
                 triggered to calculate formula. More information in references -> chapter 3.
+            conditional_distances_threshold_coeff (int): Value to be used as the numerator in the fraction (with p_cat as the denominator)
+                that defines the threshold above which the distance will be set to 1. More information in references -> chapter 3.
+
 
         Raises:
             ValueError: If feature_types is not a non-empty dict.
@@ -152,6 +157,13 @@ class Gower:
 
         self.conditional_distances = conditional_distances
         validate_conditional_distances(self.conditional_distances)
+
+        self.conditional_distances_threshold_coeff = (
+            conditional_distances_threshold_coeff
+        )
+        validate_conditional_distances_threshold_coeff(
+            self.conditional_distances_threshold_coeff
+        )
 
         self._is_fitted = False
 
@@ -551,7 +563,7 @@ class Gower:
                 return float("nan")
 
             cat_dist = cat_sum / cat_cnt
-            threshold = 1.0 / self.p_cat
+            threshold = self.conditional_distances_threshold_coeff / self.p_cat
 
             if cat_dist > threshold:
                 return 1.0

--- a/gower_metric/utils/aux.py
+++ b/gower_metric/utils/aux.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+def all_ones_off_diagonal(X: pd.DataFrame | np.ndarray) -> bool:
+    """
+    Return True if all off-diagonal elements are 1 (diagonal ignored).
+    
+    Args:
+        X (np.ndarray | pd.DataFrame): shape of (n_samples, n_features).
+            For DataFrame inputs, column names in feature_types are converted to indices.
+
+    Returns:
+        bool: True if Gower distance between all pairs of samples is equal to 1.
+
+    Raises:
+        TypeError: If X not a DataFrame or ndarray.
+
+    Example:
+        >>> from sklearn.metrics import pairwise_distances
+        >>> from gower_metric import Gower
+        >>> from gower_metric.utils.aux import all_ones_off_diagonal
+        >>> data = pd.DataFrame({
+        ...     'feature1': [[1.0], [2.0], [3.0], [4.0]],
+        ...     'feature2': ['A', 'B', 'A', 'C'],
+        ... })
+        >>> gower = Gower(feature_types={0: 'numeric_interval', 1: 'categorical_nominal'}).fit(data)
+        >>> transformed_data = gower.transform(data)
+        >>> pairwise_dist_result = pairwise_distances(transformed_data, metric=gower)
+        >>> all_ones_off_diagonal(pairwise_dist_result)
+    """
+    if isinstance(X, pd.DataFrame):
+        arr = X.values
+    elif isinstance(X, np.ndarray):
+        arr = X
+    else:
+        raise TypeError(f"Expected DataFrame or ndarray, got {type(X).__name__}")
+    
+    mask = ~np.eye(arr.shape[0], dtype=bool)
+    return bool((arr[mask] == 1).all())

--- a/gower_metric/utils/validators.py
+++ b/gower_metric/utils/validators.py
@@ -16,6 +16,7 @@ ALLOWED_CATEGORICAL_ORDINAL_CALCULATION_TYPES = {"kaufman", "podani"}
 ALLOWED_WEIGHTS_TYPES = {None, "uniform"}
 ALLOWED_K_NEIGHBOURS_TYPES = {None, int}
 ALLOWED_CONDITIONAL_DISTANCES = {False, True}
+ALLOWED_CONDITIONAL_DISTANCES_THRESHOLD_COEFF_MIN_VALUE = 1
 
 
 def validate_feature_types(feature_types: dict[Any, str]) -> None:
@@ -213,6 +214,30 @@ def validate_conditional_distances(conditional_distances: bool) -> None:
         )
 
 
+def validate_conditional_distances_threshold_coeff(
+    conditional_distances_threshold_coeff: int,
+) -> None:
+    """
+    Validate the conditional distances threshold coefficient.
+
+    Args:
+        conditional_distances_threshold_coeff (int): Value of the threshold coefficient
+
+    Raises:
+        ValueError: If conditional_distances_threshold_coeff not an int or lower than 1.
+    """
+    if (
+        not isinstance(conditional_distances_threshold_coeff, int)
+        or conditional_distances_threshold_coeff
+        < ALLOWED_CONDITIONAL_DISTANCES_THRESHOLD_COEFF_MIN_VALUE
+    ):
+        raise ValueError(
+            f"Conditional_distances_threshold_coeff must be of type `int` "
+            f"at least equal to {ALLOWED_CONDITIONAL_DISTANCES_THRESHOLD_COEFF_MIN_VALUE}, "
+            f"got {conditional_distances_threshold_coeff}"
+        )
+
+
 def validate_feature_types_for_conditional_distances(n_feats: int, p_cat: int) -> None:
     """
     Validate the data passed to use with the conditional ditances.
@@ -222,7 +247,7 @@ def validate_feature_types_for_conditional_distances(n_feats: int, p_cat: int) -
         p_cat (int): Number of categorical features
 
     Raises:
-        ValueError: If there are either no categorical or no numerical features passed
+        ValueError: If there are either no categorical or no numerical features passed.
     """
     if p_cat in (0, n_feats):
         raise ValueError(

--- a/gower_metric/utils/validators.py
+++ b/gower_metric/utils/validators.py
@@ -211,3 +211,20 @@ def validate_conditional_distances(conditional_distances: bool) -> None:
             f"Conditional_distances flag must be one of {ALLOWED_CONDITIONAL_DISTANCES}, "
             f"got {conditional_distances}"
         )
+
+
+def validate_feature_types_for_conditional_distances(n_feats: int, p_cat: int) -> None:
+    """
+    Validate the data passed to use with the conditional ditances.
+
+    Args:
+        n_feats (int): Number of passed features
+        p_cat (int): Number of categorical features
+
+    Raises:
+        ValueError: If there are either no categorical or no numerical features passed
+    """
+    if p_cat in (0, n_feats):
+        raise ValueError(
+            "For computing conditional distances both type of data: categorical and numerical need to be provided."
+        )

--- a/tests/gower_api/test_conditional_distances.py
+++ b/tests/gower_api/test_conditional_distances.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+from sklearn.metrics import pairwise_distances
 
 from gower_metric import Gower
+from gower_metric.utils.aux import all_ones_off_diagonal
 
 
 def test_conditional_distances() -> None:
@@ -183,10 +185,11 @@ def test_conditional_distances_threshold_coeff() -> None:
         conditional_distances=True,
         categorical_ordinal_values_order=categorical_ordinal_values_order,
     ).fit(raw)
+    transformed_data = gower.transform(raw)
 
-    assert gower(raw[0], raw[1]) == 1.0
-    assert gower(raw[0], raw[2]) == 1.0
-    assert gower(raw[1], raw[2]) == 1.0
+    pairwise_dist_result = pairwise_distances(transformed_data, metric=gower)
+
+    assert all_ones_off_diagonal(pairwise_dist_result)
 
     gower = Gower(
         feature_types=f_types,
@@ -194,7 +197,8 @@ def test_conditional_distances_threshold_coeff() -> None:
         conditional_distances=True,
         conditional_distances_threshold_coeff=2,
     ).fit(raw)
+    transformed_data = gower.transform(raw)
 
-    assert gower(raw[0], raw[1]) == 1.0
-    assert gower(raw[0], raw[2]) == 0.0
-    assert gower(raw[1], raw[2]) == 1.0
+    pairwise_dist_result = pairwise_distances(transformed_data, metric=gower)
+
+    assert not all_ones_off_diagonal(pairwise_dist_result)

--- a/tests/gower_api/test_conditional_distances.py
+++ b/tests/gower_api/test_conditional_distances.py
@@ -58,13 +58,18 @@ def test_conditional_distances_clip() -> None:
     )
     f_types: dict[int | str, str] = {
         0: "categorical_nominal",
-        1: "categorical_nominal",
+        1: "categorical_ordinal",
         2: "numeric",
+    }
+
+    categorical_ordinal_values_order: dict[int | str, list[str]] | None = {
+        1: ["X", "Y"],
     }
 
     gower = Gower(
         feature_types=f_types,
         conditional_distances=True,
+        categorical_ordinal_values_order=categorical_ordinal_values_order,
     ).fit(raw)
 
     assert gower(raw[0], raw[3]) == 1.0

--- a/tests/gower_api/test_conditional_distances.py
+++ b/tests/gower_api/test_conditional_distances.py
@@ -119,7 +119,7 @@ def test_value_error_on_no_numerical_features() -> None:
     }
 
     with pytest.raises(ValueError):
-        gower = Gower(
+        Gower(
             feature_types=f_types,
             conditional_distances=True,
             categorical_ordinal_values_order=categorical_ordinal_values_order,
@@ -140,7 +140,61 @@ def test_value_error_on_no_categorical_features() -> None:
     }
 
     with pytest.raises(ValueError):
-        gower = Gower(
+        Gower(
             feature_types=f_types,
             conditional_distances=True,
         ).fit(raw)
+
+
+def test_value_error_on_too_small_threshold_coeff() -> None:
+    f_types: dict[int | str, str] = {
+        0: "numeric",
+    }
+
+    with pytest.raises(ValueError):
+        Gower(
+            feature_types=f_types,
+            conditional_distances=True,
+            conditional_distances_threshold_coeff=0,
+        )
+
+
+def test_conditional_distances_threshold_coeff() -> None:
+    raw = np.array(
+        [
+            ["A", "X", 0.0],
+            ["B", "Y", 2.0],
+            ["C", "Z", 0.0],
+        ],
+        dtype=object,
+    )
+    f_types: dict[int | str, str] = {
+        0: "categorical_nominal",
+        1: "categorical_ordinal",
+        2: "numeric",
+    }
+
+    categorical_ordinal_values_order: dict[int | str, list[str]] | None = {
+        1: ["X", "Y", "Z"],
+    }
+
+    gower = Gower(
+        feature_types=f_types,
+        conditional_distances=True,
+        categorical_ordinal_values_order=categorical_ordinal_values_order,
+    ).fit(raw)
+
+    assert gower(raw[0], raw[1]) == 1.0
+    assert gower(raw[0], raw[2]) == 1.0
+    assert gower(raw[1], raw[2]) == 1.0
+
+    gower = Gower(
+        feature_types=f_types,
+        categorical_ordinal_values_order=categorical_ordinal_values_order,
+        conditional_distances=True,
+        conditional_distances_threshold_coeff=2,
+    ).fit(raw)
+
+    assert gower(raw[0], raw[1]) == 1.0
+    assert gower(raw[0], raw[2]) == 0.0
+    assert gower(raw[1], raw[2]) == 1.0

--- a/tests/gower_api/test_conditional_distances.py
+++ b/tests/gower_api/test_conditional_distances.py
@@ -98,3 +98,49 @@ def test_conditional_distances_clip() -> None:
             dist = gower(raw[i], raw[j])
 
             assert pytest.approx(dist, rel=1e-6) == expected[i, j]
+
+
+def test_value_error_on_no_numerical_features() -> None:
+    raw = np.array(
+        [
+            [True, "A", "X"],
+            [False, "B", "X"],
+        ],
+        dtype=object,
+    )
+    f_types: dict[int | str, str] = {
+        0: "binary_asymmetric",
+        1: "categorical_nominal",
+        2: "categorical_ordinal",
+    }
+
+    categorical_ordinal_values_order: dict[int | str, list[str]] | None = {
+        2: ["X", "Y"],
+    }
+
+    with pytest.raises(ValueError):
+        gower = Gower(
+            feature_types=f_types,
+            conditional_distances=True,
+            categorical_ordinal_values_order=categorical_ordinal_values_order,
+        ).fit(raw)
+
+
+def test_value_error_on_no_categorical_features() -> None:
+    raw = np.array(
+        [
+            [12, 100.0],
+            [15, 150.0],
+        ],
+        dtype=object,
+    )
+    f_types: dict[int | str, str] = {
+        0: "numeric",
+        1: "ratio_scale_interval",
+    }
+
+    with pytest.raises(ValueError):
+        gower = Gower(
+            feature_types=f_types,
+            conditional_distances=True,
+        ).fit(raw)

--- a/tests/gower_api/test_input_transformer.py
+++ b/tests/gower_api/test_input_transformer.py
@@ -10,7 +10,9 @@ def test_transform_before_fit() -> None:
     data = np.array([[0], [1], [0]], dtype=object)
     gower = Gower({0: "binary_symmetric"})
 
-    with pytest.raises(IllegalStateError, match="Operation not allowed: model is not fitted"):
+    with pytest.raises(
+        IllegalStateError, match="Operation not allowed: model is not fitted"
+    ):
         gower.transform(data)
 
 


### PR DESCRIPTION
Add the following refinements to conditional distances:

1. Treat categorical ordinal columns as simple categorical columns and include them into p_cat.
1. Raise error when the dataset has either all columns categorical or numerical.
1. Allow threshold coefficient modification.
1. Add `all_ones_off_diagonal` utils function to check the validity of using conditional distance with selected threshold coefficient.